### PR TITLE
Add multiple hashtags support and search only new tweets

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,8 @@
         "easycorp/easyadmin-bundle": "^1.17",
         "guzzlehttp/guzzle": "^6.3",
         "guzzlehttp/oauth-subscriber": "^0.3.0",
+        "ramsey/uuid": "^3.7",
+        "ramsey/uuid-doctrine": "^1.4",
         "sensio/framework-extra-bundle": "^5.1",
         "symfony/console": "^4.0",
         "symfony/flex": "^1.0",

--- a/src/Command/TweetFetchCommand.php
+++ b/src/Command/TweetFetchCommand.php
@@ -70,7 +70,7 @@ EOD
         $io->title(sprintf('Searching tweets for: %s', $text));
 
         $hashtag = $this->obtainHashtagFromText($text, $persist);
-        $tweetSearch = $this->twitterClient->findTweetsWith($hashtag->getName(), $include_entities, $result_type, $count);
+        $tweetSearch = $this->twitterClient->findTweetsWith($hashtag, $include_entities, $result_type, $count);
         $this->buildAndShowTweets($tweetSearch->statuses, $hashtag, $io, $persist);
 
         $io->success('Operation finished!');
@@ -115,6 +115,7 @@ EOD
         }
 
         if ($persist) {
+            $this->updateHashtagLastTweet($hashtag, ... $tweetsToSave);
             $this->saveTweets(... $tweetsToSave);
             $io->note(sprintf('Saved %d tweets!', count($tweetsToSave)));
         }
@@ -122,9 +123,16 @@ EOD
         return $tweetsToSave;
     }
 
+    private function updateHashtagLastTweet(Hashtag $hashtag, Tweet ...$tweets)
+    {
+        $lastIndex = count($tweets) - 1;
+        $hashtag->setLastTweet($tweets[$lastIndex]->getTweetId());
+        $this->hashtagRepository->save($hashtag);
+    }
+
     private function saveTweets(Tweet ...$tweets)
     {
-        if (empty($tweet))
+        if (empty($tweets))
         {
             return;
         }

--- a/src/Entity/Hashtag.php
+++ b/src/Entity/Hashtag.php
@@ -31,9 +31,9 @@ class Hashtag
     private $tweet;
 
     /**
-     * @ORM\Column(type="datetime_immutable", nullable=true)
+     * @ORM\Column(type="integer", nullable=true)
      */
-    private $lastSearch;
+    private $lastTweet;
 
     public function __construct()
     {
@@ -104,14 +104,14 @@ class Hashtag
         return $this;
     }
 
-    public function getLastSearch(): ?\DateTimeImmutable
+    public function getLastTweet(): ?int
     {
-        return $this->lastSearch;
+        return $this->lastTweet;
     }
 
-    public function setLastSearch(?\DateTimeImmutable $lastSearch): self
+    public function setLastTweet(?int $lastTweet): self
     {
-        $this->lastSearch = $lastSearch;
+        $this->lastTweet = $lastTweet;
 
         return $this;
     }

--- a/src/Entity/Hashtag.php
+++ b/src/Entity/Hashtag.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Ramsey\Uuid\Uuid;
+
+/**
+ * @ORM\Entity(repositoryClass="App\Repository\HashtagRepository")
+ */
+class Hashtag
+{
+    /**
+     * @ORM\Id()
+     * @ORM\Column(type="uuid", unique=true)
+     * @ORM\GeneratedValue(strategy="CUSTOM")
+     * @ORM\CustomIdGenerator(class="Ramsey\Uuid\Doctrine\UuidGenerator")
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(type="string", length=100, nullable=true)
+     */
+    private $name;
+
+    /**
+     * @ORM\OneToMany(targetEntity="App\Entity\Tweet", mappedBy="hashtag", orphanRemoval=true)
+     */
+    private $tweet;
+
+    /**
+     * @ORM\Column(type="datetime_immutable", nullable=true)
+     */
+    private $lastSearch;
+
+    public function __construct()
+    {
+        $this->tweet = new ArrayCollection();
+    }
+
+    public static function fromName(string $string) : self
+    {
+        $hashtag = new self();
+        $hashtag->generateId();
+        $hashtag->setName($string);
+        return $hashtag;
+    }
+
+    private function generateId()
+    {
+        $this->id = Uuid::uuid4()->toString();
+    }
+
+    public function getId() : Uuid
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        if (!empty($this->name)) {
+            throw new \Exception("The Hashtag can't be changed");
+        }
+
+        $this->name = $name;
+        return $this;
+    }
+
+    /**
+     * @return Collection|Tweet[]
+     */
+    public function getTweet(): Collection
+    {
+        return $this->tweet;
+    }
+
+    public function addTweet(Tweet $name): self
+    {
+        if (!$this->tweet->contains($name)) {
+            $this->tweet[] = $name;
+            $name->setHashtag($this);
+        }
+
+        return $this;
+    }
+
+    public function removeTweet(Tweet $name): self
+    {
+        if ($this->tweet->contains($name)) {
+            $this->tweet->removeElement($name);
+            // set the owning side to null (unless already changed)
+            if ($name->getHashtag() === $this) {
+                $name->setHashtag(null);
+            }
+        }
+
+        return $this;
+    }
+
+    public function getLastSearch(): ?\DateTimeImmutable
+    {
+        return $this->lastSearch;
+    }
+
+    public function setLastSearch(?\DateTimeImmutable $lastSearch): self
+    {
+        $this->lastSearch = $lastSearch;
+
+        return $this;
+    }
+}

--- a/src/Entity/Tweet.php
+++ b/src/Entity/Tweet.php
@@ -47,6 +47,29 @@ class Tweet
     private $createdAt;
 
     /**
+     * @ORM\ManyToOne(targetEntity="App\Entity\Hashtag", inversedBy="tweet")
+     * @ORM\JoinColumn(nullable=false)
+     */
+    private $hashtag;
+
+    public static function buildAndAttachToHashtag(\StdClass $tweet, Hashtag $hashtag) : self
+    {
+        $originalTweetUsername = isset($tweet->retweeted_status) ? $tweet->retweeted_status->user->screen_name : null;
+
+        $entity = new self;
+        $entity
+            ->setTweetId($tweet->id)
+            ->setContent($tweet->text)
+            ->setUserName($tweet->user->screen_name)
+            ->setOriginalTweetUsername($originalTweetUsername)
+            ->setUserImage($tweet->user->profile_image_url)
+            ->setCreatedAt(new \DateTime($tweet->created_at))
+            ->setHashtag($hashtag);
+
+        return $entity;
+    }
+
+    /**
      * @return mixed
      */
     public function getId()
@@ -177,5 +200,17 @@ class Tweet
     public function getLink()
     {
         return  "<a href='https://twitter.com/{$this->getUserName()}/status/{$this->getTweetId()}' target='_blank'>{$this->getTweetId()}</a>";
+    }
+
+    public function getHashtag(): ?Hashtag
+    {
+        return $this->hashtag;
+    }
+
+    public function setHashtag(?Hashtag $hashtag): self
+    {
+        $this->hashtag = $hashtag;
+
+        return $this;
     }
 }

--- a/src/Repository/HashtagRepository.php
+++ b/src/Repository/HashtagRepository.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Hashtag;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Common\Collections\Collection;
+use Symfony\Bridge\Doctrine\RegistryInterface;
+
+/**
+ * @method Hashtag|null find($id, $lockMode = null, $lockVersion = null)
+ * @method Hashtag|null findOneBy(array $criteria, array $orderBy = null)
+ * @method Hashtag[]    findAll()
+ * @method Hashtag[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class HashtagRepository extends ServiceEntityRepository
+{
+    public function __construct(RegistryInterface $registry)
+    {
+        parent::__construct($registry, Hashtag::class);
+    }
+
+    public function findOneByName(string $value) : ? Hashtag
+    {
+        return $this->findOneBy(['name' => $value]);
+    }
+
+    public function save(Hashtag $hashtag) : void
+    {
+        $this->_em->persist($hashtag);
+        $this->_em->flush();
+    }
+
+//    /**
+//     * @return Hashtag[] Returns an array of Hashtag objects
+//     */
+    /*
+    public function findByExampleField($value)
+    {
+        return $this->createQueryBuilder('h')
+            ->andWhere('h.exampleField = :val')
+            ->setParameter('val', $value)
+            ->orderBy('h.id', 'ASC')
+            ->setMaxResults(10)
+            ->getQuery()
+            ->getResult()
+        ;
+    }
+    */
+
+    /*
+    public function findOneBySomeField($value): ?Hashtag
+    {
+        return $this->createQueryBuilder('h')
+            ->andWhere('h.exampleField = :val')
+            ->setParameter('val', $value)
+            ->getQuery()
+            ->getOneOrNullResult()
+        ;
+    }
+    */
+}

--- a/src/Service/TwitterClient.php
+++ b/src/Service/TwitterClient.php
@@ -2,6 +2,7 @@
 
 namespace App\Service;
 
+use App\Entity\Hashtag;
 use GuzzleHttp\Client;
 
 class TwitterClient extends Client
@@ -14,29 +15,33 @@ class TwitterClient extends Client
     /**
      * Find tweets by text.
      *
-     * @param $text
-     * @param bool   $include_entities
+     * @param Hashtag $hashtag
+     * @param bool $include_entities
      * @param string $result_type
-     * @param int    $count
+     * @param int $count
      *
      * @return array
      */
     public function findTweetsWith(
-        $text,
+        Hashtag $hashtag,
         $include_entities = false,
         $result_type = 'recent',
         $count = 4
     ) {
         try {
-            $JSONResponse = $this->get('search/tweets.json', [
+
+            $options = [
                 'auth' => 'oauth',
                 'query' => [
-                    'q' => $text,
+                    'q' => $hashtag->getName(),
                     'include_entities' => $include_entities,
                     'result_type' => $result_type,
                     'count' => $count,
-                ],
-            ])->getBody()->getContents();
+                    'since_id' => $hashtag->getLastTweet()
+                ]
+            ];
+
+            $JSONResponse = $this->get('search/tweets.json', $options)->getBody()->getContents();
 
             return json_decode($JSONResponse);
         } catch (\Exception $e) {


### PR DESCRIPTION
Create a Hashtag entity to persist the text to search.

The hashtag or query used in the TweetFetchCommand is persisted and all the results are stored related to the Hashtag.

When persist the tweets, the hashtag is upgraded with the last tweet ID. This last tweet ID is used by the Twitter Client to search tweets since the last tweet ID